### PR TITLE
Support EUR base currency with BGN display

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A WordPress plugin that adds dual pricing (BGN/EUR) support for SureCart in comp
 
 ## Description
 
-This plugin extends SureCart to automatically display prices in both Bulgarian Lev (BGN) and Euro (EUR) on product pages. This is required by Bulgarian law, which mandates that prices must be displayed in both the national currency (BGN) and Euro for consumer transparency.
+This plugin extends SureCart to automatically display prices in both Bulgarian Lev (BGN) and Euro (EUR) on product pages and shop pages. This is required by Bulgarian law, which mandates that prices must be displayed in both the national currency (BGN) and Euro for consumer transparency.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A WordPress plugin that adds dual pricing (BGN/EUR) support for SureCart in comp
 
 ## Description
 
-This plugin extends SureCart to automatically display prices in both Bulgarian Lev (BGN) and Euro (EUR) on product pages and shop pages. This is required by Bulgarian law, which mandates that prices must be displayed in both the national currency (BGN) and Euro for consumer transparency.
+This plugin extends SureCart to automatically display prices in both Bulgarian Lev (BGN) and Euro (EUR) on product pages. This is required by Bulgarian law, which mandates that prices must be displayed in both the national currency (BGN) and Euro for consumer transparency.
 
 ### Features
 
-- **Automatic Currency Conversion**: Automatically converts BGN prices to EUR using the official exchange rate
+- **Automatic Currency Conversion**: Automatically converts EUR prices to BGN using the official exchange rate
 - **Dual Price Display**: Shows both BGN and EUR prices on product pages
 - **Variant Support**: Handles dual pricing for product variants
 - **List Price Support**: Displays both currencies for comparison/list prices
@@ -18,8 +18,8 @@ This plugin extends SureCart to automatically display prices in both Bulgarian L
 
 The plugin hooks into SureCart's price rendering system and:
 
-1. Detects when prices are displayed in BGN
-2. Calculates the equivalent EUR amount using the conversion rate
+1. Detects when prices are displayed in EUR
+2. Calculates the equivalent BGN amount using the conversion rate
 3. Displays both currencies to customers on the frontend
 
 ## ⚠️ Legal Disclaimer
@@ -40,7 +40,7 @@ By using this plugin, you accept full responsibility for its implementation and 
 - WordPress 6.0 or higher
 - PHP 7.4 or higher
 - **SureCart Plugin** (must be installed and activated)
-- You must have Bulgarian currency as your store currency.
+- You must have Euro as your store currency.
 
 ## Installation
 
@@ -64,8 +64,8 @@ By using this plugin, you accept full responsibility for its implementation and 
 
 Once activated, the plugin will automatically:
 
-- Display dual pricing on all SureCart product pages and shop pages with BGN currency
-- Show EUR equivalents alongside BGN prices using the standard €1 = 1.95583 BGN.
+- Display dual pricing on all SureCart product pages and shop pages with EUR currency
+- Show BGN equivalents alongside EUR prices using the standard 1 EUR = 1.95583 BGN.
 - No additional configuration required!
 
 ## Usage
@@ -73,8 +73,8 @@ Once activated, the plugin will automatically:
 The plugin works automatically once activated. Simply:
 
 1. Create or edit your SureCart products as usual
-2. Set prices in BGN
-3. The plugin will automatically display the both BGN and EUR in product list pages and single product pages.
+2. Set prices in EUR
+3. The plugin will automatically display the BGN equivalent on the frontend
 
 ## Support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surecart-bulgaria-dual-pricing",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "surecart-bulgaria-dual-pricing.js",
   "files": [

--- a/surcart-bulgaria-dual-pricing.php
+++ b/surcart-bulgaria-dual-pricing.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: SureCart Bulgaria Dual Pricing
  * Description: Dual pricing for SureCart in Bulgaria.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: SureCart
  * Author URI: https://surecart.com
  */

--- a/surecart-bulgaria-dual-pricing.js
+++ b/surecart-bulgaria-dual-pricing.js
@@ -8,23 +8,23 @@ store("surecart/bulgaria-dual-pricing", {
     get selectedDisplayAmount() {
       const { prices, selectedPrice } = getContext("surecart/product-page");
       const { state: productPageState } = store("surecart/product-page");
-      const { euroPrices, euroVariants } = getContext(
+      const { bgnPrices, bgnVariants } = getContext(
         "surecart/bulgaria-dual-pricing"
       );
-      const selectedEuroPrice = euroPrices.find(
+      const selectedBgnPrice = bgnPrices.find(
         (price) => price.id === selectedPrice.id
       );
-      const selectedEuroVariant = euroVariants.find(
+      const selectedBgnVariant = bgnVariants.find(
         (variant) => variant.id === productPageState.selectedVariant.id
       );
 
       if (prices?.length > 1) {
-        return selectedEuroPrice?.euro_display_amount || "";
+        return selectedBgnPrice?.bgn_display_amount || "";
       }
 
       return (
-        selectedEuroVariant?.euro_display_amount ||
-        selectedEuroPrice?.euro_display_amount ||
+        selectedBgnVariant?.bgn_display_amount ||
+        selectedBgnPrice?.bgn_display_amount ||
         ""
       );
     },

--- a/surecart-bulgaria-set-pricing-attribute.php
+++ b/surecart-bulgaria-set-pricing-attribute.php
@@ -44,20 +44,20 @@ class SureCartBulgariaSetPricingAttribute {
         $product = sc_get_product();
 
         return array(
-            'euroPrices'   => array_map(
+            'bgnPrices'   => array_map(
                 fn( $price ) => $price->only(
                     array(
                         'id',
-                        'euro_display_amount',
+                        'bgn_display_amount',
                     )
                 ),
                 $product->active_prices ?? array()
             ),
-            'euroVariants' => array_map(
+            'bgnVariants' => array_map(
                 fn( $variant ) => $variant->only(
                     array(
                         'id',
-                        'euro_display_amount',
+                        'bgn_display_amount',
                     )
                 ),
                 $product->variants->data ?? array()
@@ -145,7 +145,7 @@ class SureCartBulgariaSetPricingAttribute {
 
         $product = sc_get_product();
 
-        $additional_content = $product->initial_price->euro_display_amount;
+        $additional_content = $product->initial_price->bgn_display_amount;
 
 		// Use WP_HTML_Tag_Processor to inject content inside the wrapper.
 		$processor = new WP_HTML_Tag_Processor( $block_content );
@@ -195,11 +195,11 @@ class SureCartBulgariaSetPricingAttribute {
 	* @return void
 	*/
 	public function set_pricing_attribute( $price ) {
-        if ( 'bgn' !== $price->currency ) {
+        if ( 'eur' !== $price->currency ) {
             return $price->display_amount;
         }
-        $euro_amount = $price->amount / 1.95583; // Convert BGN to EUR using fixed rate: €1 = 1.95583 BGN
-		$euro_display_amount = empty( $euro_amount ) ? '' : Currency::format( $euro_amount, 'eur' );
-		$price->setAttribute( 'euro_display_amount', $euro_display_amount );
+        $bgn_amount = $price->amount * 1.95583; // Convert EUR to BGN using fixed rate: 1 EUR = 1.95583 BGN.
+		$bgn_display_amount = empty( $bgn_amount ) ? '' : Currency::format( $bgn_amount, 'bgn' );
+		$price->setAttribute( 'bgn_display_amount', $bgn_display_amount );
 	}
 }


### PR DESCRIPTION
## Summary
Switch dual pricing to use EUR as the base currency while showing BGN equivalents, without mutating the entered EUR price.

## Details
- Only compute/display gn_display_amount
- Keep the original EUR price intact
- Bump plugin version to 1.0.1

Fixes #1